### PR TITLE
feat: encapsulate PlayerInstance into GstPlayer widget and controller

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,12 +20,9 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   String _platformVersion = 'Unknown';
-  final List<String> _playerLogs = [];
-  final ScrollController _logScrollController = ScrollController();
   final _mediaGstPlugin = MediaGst();
   
-  PlayerInstance? _player;
-  StreamSubscription<PlayerEvent>? _eventSubscription;
+  final GstPlayerController _playerController = GstPlayerController();
   final TextEditingController _uriController = TextEditingController(
     text: 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
   );
@@ -38,8 +35,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
-    _eventSubscription?.cancel();
-    _player?.dispose();
+    _playerController.dispose();
     _uriController.dispose();
     super.dispose();
   }
@@ -61,96 +57,58 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
-  void _addLog(String msg) {
-    if (!mounted) return;
-    setState(() {
-      final time = DateTime.now().toIso8601String().split('T')[1].substring(0, 8);
-      _playerLogs.add('[$time] $msg');
-    });
-    Future.delayed(const Duration(milliseconds: 50), () {
-      if (!mounted) return;
-      if (_logScrollController.hasClients) {
-        _logScrollController.animateTo(
-          _logScrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOut,
-        );
-      }
-    });
-  }
-
   Future<void> _createAndPlay() async {
-    try {
-      // 1. 플레이어 생성
-      final player = await createPlayer();
-      if (mounted) {
-        setState(() {
-          _player?.dispose();
-          _player = player;
-        });
-      }
-      _addLog('Created');
-
-      // 2. 이벤트 구독 (상태 변경, 버퍼링 등)
-      _eventSubscription?.cancel();
-      _eventSubscription = subscribePlayerEvents(player: player).listen((event) {
-        if (!mounted) return;
-        event.when(
-          stateChanged: (state) => _addLog('State: ${state.name}'),
-          error: (err) => _addLog('Error: $err'),
-          endOfStream: () => _addLog('EOS (End of Stream)'),
-          buffering: (percent) => _addLog('Buffering: $percent%'),
-          clockLost: () => _addLog('Clock Lost'),
-        );
-      });
-
-      // 3. 소스 URI 설정
-      _addLog('Setting Source...');
-      await setSource(player: player, uri: _uriController.text);
-
-      // 4. 재생 시작
-      _addLog('Playing...');
-      await play(player: player);
-
-    } catch (e) {
-      if (mounted) {
-        _addLog('Exception: $e');
-      }
-    }
+    await _playerController.initialize(_uriController.text);
+    await _playerController.playStream();
   }
 
   Future<void> _stopPlayer() async {
-    if (_player != null) {
-      try {
-        await stop(player: _player!);
-      } catch (e) {
-        debugPrint('Failed to stop: $e');
-      } finally {
-        if (mounted) {
-          setState(() {
-            _eventSubscription?.cancel();
-            _eventSubscription = null;
-            _player?.dispose();
-            _player = null;
-          });
-          _addLog('Player Stopped and Disposed.');
-        }
-      }
-    }
+    await _playerController.stopStream();
+  }
+  
+  Future<void> _pausePlayer() async {
+    await _playerController.pauseStream();
   }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        appBar: AppBar(title: const Text('MediaGst Example')),
+        appBar: AppBar(title: const Text('MediaGst Player Widget Example')),
         body: Padding(
           padding: const EdgeInsets.all(16.0),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Text('Running on: $_platformVersion'),
+              const SizedBox(height: 10),
+              
+              // 비디오 위젯 영역
+              Container(
+                height: 300,
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.grey),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                clipBehavior: Clip.hardEdge,
+                child: GstPlayer(controller: _playerController),
+              ),
               const SizedBox(height: 20),
+
+              // 현재 상태 표시 영역
+              ListenableBuilder(
+                listenable: _playerController,
+                builder: (context, _) {
+                  return Text(
+                    '상태: ${_playerController.state.name} | '
+                    '버퍼링: ${_playerController.bufferingPercent}%',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  );
+                },
+              ),
+              const SizedBox(height: 20),
+
               TextField(
                 controller: _uriController,
                 decoration: const InputDecoration(
@@ -158,39 +116,24 @@ class _MyAppState extends State<MyApp> {
                   border: OutlineInputBorder(),
                 ),
               ),
-              const SizedBox(height: 10),
-              Expanded(
-                child: Container(
-                  padding: const EdgeInsets.all(8.0),
-                  decoration: BoxDecoration(
-                    border: Border.all(color: Colors.grey),
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                  width: double.infinity,
-                  child: ListView.builder(
-                    controller: _logScrollController,
-                    itemCount: _playerLogs.length,
-                    itemBuilder: (context, index) {
-                      return Text(
-                        _playerLogs[index],
-                        style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
-                      );
-                    },
-                  ),
-                ),
-              ),
               const SizedBox(height: 20),
+              
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   ElevatedButton(
                     onPressed: _createAndPlay,
-                    child: const Text('Play URI'),
+                    child: const Text('초기화 & 재생'),
                   ),
-                  const SizedBox(width: 10),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: _pausePlayer,
+                    child: const Text('일시정지'),
+                  ),
+                  const SizedBox(width: 8),
                   ElevatedButton(
                     onPressed: _stopPlayer,
-                    child: const Text('Stop'),
+                    child: const Text('정지'),
                   ),
                 ],
               ),

--- a/lib/media_gst.dart
+++ b/lib/media_gst.dart
@@ -7,8 +7,8 @@
 
 import 'media_gst_platform_interface.dart';
 import 'src/rust/frb_generated.dart';
-export 'src/rust/api.dart';
-export 'src/rust/player_instance.dart';
+export 'src/rust/player_instance.dart' show PlayerState;
+export 'src/widgets/gst_player.dart';
 
 class MediaGst {
   /// Initializes the GStreamer Rust backend.

--- a/lib/src/widgets/gst_player.dart
+++ b/lib/src/widgets/gst_player.dart
@@ -28,12 +28,21 @@ class GstPlayerController extends ChangeNotifier {
   Future<void> initialize(String uri) async {
     try {
       _errorMessage = null;
-      _player?.dispose();
-      
+
+      if (_eventSubscription != null) {
+        await _eventSubscription!.cancel();
+        _eventSubscription = null;
+      }
+      if (_player != null) {
+        _player!.dispose();
+        _player = null;
+      }
+
       _player = await createPlayer();
-      _eventSubscription?.cancel();
-      _eventSubscription = subscribePlayerEvents(player: _player!).listen(_onPlayerEvent);
-      
+      _eventSubscription = subscribePlayerEvents(
+        player: _player!,
+      ).listen(_onPlayerEvent);
+
       await setSource(player: _player!, uri: uri);
       _isInitialized = true;
       notifyListeners();
@@ -102,89 +111,64 @@ class GstPlayerController extends ChangeNotifier {
 }
 
 /// GStreamer 비디오 플레이어를 렌더링하는 위젯
-class GstPlayer extends StatefulWidget {
+class GstPlayer extends StatelessWidget {
   final GstPlayerController controller;
 
   const GstPlayer({super.key, required this.controller});
 
   @override
-  State<GstPlayer> createState() => _GstPlayerState();
-}
-
-class _GstPlayerState extends State<GstPlayer> {
-  @override
-  void initState() {
-    super.initState();
-    widget.controller.addListener(_onControllerUpdate);
-  }
-
-  @override
-  void didUpdateWidget(covariant GstPlayer oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.controller != widget.controller) {
-      oldWidget.controller.removeListener(_onControllerUpdate);
-      widget.controller.addListener(_onControllerUpdate);
-    }
-  }
-
-  @override
-  void dispose() {
-    widget.controller.removeListener(_onControllerUpdate);
-    super.dispose();
-  }
-
-  void _onControllerUpdate() {
-    setState(() {});
-  }
-
-  @override
   Widget build(BuildContext context) {
-    if (widget.controller.errorMessage != null) {
-      return Center(
-        child: Text(
-          'Error: ${widget.controller.errorMessage}',
-          style: const TextStyle(color: Colors.red),
-        ),
-      );
-    }
-
-    if (!widget.controller.isInitialized) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
-    Widget videoLayer;
-    if (widget.controller.textureId != null) {
-      videoLayer = Texture(textureId: widget.controller.textureId!);
-    } else {
-      videoLayer = Container(
-        color: Colors.black,
-        child: const Center(
-          child: Text(
-            '오디오 전용 또는 외부 윈도우 렌더링 중',
-            style: TextStyle(color: Colors.white),
-          ),
-        ),
-      );
-    }
-
-    return Stack(
-      children: [
-        videoLayer,
-        if (widget.controller.bufferingPercent > 0 && widget.controller.bufferingPercent < 100)
-          Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const CircularProgressIndicator(),
-                const SizedBox(height: 8),
-                Text(
-                  'Buffering ${widget.controller.bufferingPercent}%',
-                  style: const TextStyle(color: Colors.white),
-                ),
-              ],
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, _) {
+        if (controller.errorMessage != null) {
+          return Center(
+            child: Text(
+              'Error: ${controller.errorMessage}',
+              style: const TextStyle(color: Colors.red),
             ),
-          ),
-      ],
+          );
+        }
+
+        if (!controller.isInitialized) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        Widget videoLayer;
+        if (controller.textureId != null) {
+          videoLayer = Texture(textureId: controller.textureId!);
+        } else {
+          videoLayer = Container(
+            color: Colors.black,
+            child: const Center(
+              child: Text(
+                '오디오 전용 또는 외부 윈도우 렌더링 중',
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+          );
+        }
+
+        return Stack(
+          children: [
+            videoLayer,
+            if (controller.bufferingPercent > 0 && controller.bufferingPercent < 100)
+              Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const CircularProgressIndicator(),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Buffering ${controller.bufferingPercent}%',
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/src/widgets/gst_player.dart
+++ b/lib/src/widgets/gst_player.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+import '../rust/api.dart';
+import '../rust/player_instance.dart';
+
+/// 컨트롤러: GStreamer 플레이어(PlayerInstance)의 상태와 동작을 관리합니다.
+class GstPlayerController extends ChangeNotifier {
+  PlayerInstance? _player;
+  StreamSubscription<PlayerEvent>? _eventSubscription;
+
+  PlayerState _state = PlayerState.stop;
+  PlayerState get state => _state;
+
+  bool _isInitialized = false;
+  bool get isInitialized => _isInitialized;
+
+  String? _errorMessage;
+  String? get errorMessage => _errorMessage;
+
+  int _bufferingPercent = 0;
+  int get bufferingPercent => _bufferingPercent;
+
+  /// 향후 ExternalTexture 지원 시 사용될 textureId
+  int? get textureId => null;
+
+  /// 플레이어를 생성하고 URI를 설정하여 초기화합니다.
+  Future<void> initialize(String uri) async {
+    try {
+      _errorMessage = null;
+      _player?.dispose();
+      
+      _player = await createPlayer();
+      _eventSubscription?.cancel();
+      _eventSubscription = subscribePlayerEvents(player: _player!).listen(_onPlayerEvent);
+      
+      await setSource(player: _player!, uri: uri);
+      _isInitialized = true;
+      notifyListeners();
+    } catch (e) {
+      _errorMessage = e.toString();
+      _isInitialized = false;
+      notifyListeners();
+    }
+  }
+
+  void _onPlayerEvent(PlayerEvent event) {
+    event.when(
+      stateChanged: (newState) {
+        _state = newState;
+        notifyListeners();
+      },
+      error: (err) {
+        _errorMessage = err;
+        notifyListeners();
+      },
+      endOfStream: () {
+        _state = PlayerState.stop;
+        notifyListeners();
+      },
+      buffering: (percent) {
+        _bufferingPercent = percent;
+        notifyListeners();
+      },
+      clockLost: () {
+        debugPrint('MediaGst: Clock Lost');
+      },
+    );
+  }
+
+  /// 재생 시작
+  Future<void> playStream() async {
+    if (_player != null) {
+      await play(player: _player!);
+    }
+  }
+
+  /// 재생 일시정지
+  Future<void> pauseStream() async {
+    if (_player != null) {
+      await pause(player: _player!);
+    }
+  }
+
+  /// 재생 정지
+  Future<void> stopStream() async {
+    if (_player != null) {
+      await stop(player: _player!);
+    }
+  }
+
+  @override
+  void dispose() {
+    _eventSubscription?.cancel();
+    if (_player != null) {
+      stop(player: _player!).ignore();
+      _player?.dispose();
+      _player = null;
+    }
+    super.dispose();
+  }
+}
+
+/// GStreamer 비디오 플레이어를 렌더링하는 위젯
+class GstPlayer extends StatefulWidget {
+  final GstPlayerController controller;
+
+  const GstPlayer({super.key, required this.controller});
+
+  @override
+  State<GstPlayer> createState() => _GstPlayerState();
+}
+
+class _GstPlayerState extends State<GstPlayer> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onControllerUpdate);
+  }
+
+  @override
+  void didUpdateWidget(covariant GstPlayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onControllerUpdate);
+      widget.controller.addListener(_onControllerUpdate);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onControllerUpdate);
+    super.dispose();
+  }
+
+  void _onControllerUpdate() {
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.controller.errorMessage != null) {
+      return Center(
+        child: Text(
+          'Error: ${widget.controller.errorMessage}',
+          style: const TextStyle(color: Colors.red),
+        ),
+      );
+    }
+
+    if (!widget.controller.isInitialized) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    Widget videoLayer;
+    if (widget.controller.textureId != null) {
+      videoLayer = Texture(textureId: widget.controller.textureId!);
+    } else {
+      videoLayer = Container(
+        color: Colors.black,
+        child: const Center(
+          child: Text(
+            '오디오 전용 또는 외부 윈도우 렌더링 중',
+            style: TextStyle(color: Colors.white),
+          ),
+        ),
+      );
+    }
+
+    return Stack(
+      children: [
+        videoLayer,
+        if (widget.controller.bufferingPercent > 0 && widget.controller.bufferingPercent < 100)
+          Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const CircularProgressIndicator(),
+                const SizedBox(height: 8),
+                Text(
+                  'Buffering ${widget.controller.bufferingPercent}%',
+                  style: const TextStyle(color: Colors.white),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- GStreamer의 `PlayerInstance` 상태와 이벤트를 캡슐화하여 관리하는 `GstPlayerController` 구현
- 컨트롤러의 상태에 따라 UI를 업데이트하고 렌더링하는 `GstPlayer` 위젯 추가
- `media_gst.dart`의 외부 노출을 정리하여 하위 API(`.rust/api.dart`, `PlayerInstance`)를 숨기고, `PlayerState`만 제한적으로 export 하도록 패키지 인터페이스 개선
- `example/lib/main.dart`가 새로운 위젯 아키텍처를 사용하도록 예제 코드 리팩토링